### PR TITLE
Resolving build issues with powershell and M1 Apple Chip capability

### DIFF
--- a/omega/.idea/.gitignore
+++ b/omega/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/omega/.idea/inspectionProfiles/profiles_settings.xml
+++ b/omega/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/omega/.idea/modules.xml
+++ b/omega/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/omega.iml" filepath="$PROJECT_DIR$/.idea/omega.iml" />
+    </modules>
+  </component>
+</project>

--- a/omega/.idea/omega.iml
+++ b/omega/.idea/omega.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+</module>

--- a/omega/.idea/vcs.xml
+++ b/omega/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/omega/analyzer/Dockerfile
+++ b/omega/analyzer/Dockerfile
@@ -1,5 +1,5 @@
-FROM --platform=linux/amd64 mcr.microsoft.com/mirror/docker/library/ubuntu:22.04
-
+#FROM --platform=linux/amd64 mcr.microsoft.com/mirror/docker/library/ubuntu:22.04
+FROM mcr.microsoft.com/mirror/docker/library/ubuntu:22.04
 # Copyright (C) Microsoft Corporation, All rights reserved.
 
 LABEL schema-version="1.0"
@@ -16,10 +16,11 @@ ARG OSSGADGET_VERSION="0.1.365"
 ARG GO_VERSION="1.19.3"
 ARG BRAKEMAN_VERSION="v5.4.0"
 ARG SCC_VERSION="3.0.0"
-ARG NODE_VERSION="18.x"
+ARG NODE_VERSION="19.x"
 ARG DEVSKIM_VERSION="0.8.4-alpha"
 ARG RADARE2_VERSION="5.7.8"
 ARG CODEQL_VERSION="v2.11.6"
+ARG UBUNTU_VERSION="22.04"
 
 # Initialize some things
 ARG DEBIAN_FRONTEND=noninteractive
@@ -105,6 +106,7 @@ RUN apt-get update && \
             sudo \
             openssh-client \
             openjdk-17-jdk
+#    apt-get update
 
 ##################################
 ####### Install Core Tools #######
@@ -114,17 +116,17 @@ RUN apt-get update && \
 # License: https://github.com/dotnet/core/blob/main/LICENSE.TXT
 # License: https://github.com/PowerShell/PowerShell/blob/master/LICENSE.txt
 # Workaround with /etc/apt/preferences based on https://github.com/dotnet/core/issues/7699
-#RUN cd /tmp && \
-#    wget -q a -O packages-microsoft-prod.deb && \
-#    dpkg -i packages-microsoft-prod.deb && \
-#    rm packages-microsoft-prod.deb && \
-#    touch /etc/apt/preferences && \
-#    echo "Package: *" >> /etc/apt/preferences && \
-#    echo "Pin: origin \"packages.microsoft.com\"" >> /etc/apt/preferences && \
-#    echo "Pin-Priority: 1001" >> /etc/apt/preferences && \
-#    add-apt-repository universe && \
-#    apt update && \
-#    apt-get install -y dotnet-sdk-${DOTNET_VERSION} && \
+RUN cd /tmp
+RUN wget -q -a -O https://packages.microsoft.com/config/ubuntu/${UBUNTU_VERSION}/packages-microsoft-prod.deb && \
+    dpkg -i packages-microsoft-prod.deb && \
+    rm packages-microsoft-prod.deb && \
+    touch /etc/apt/preferences && \
+    echo "Package: *" >> /etc/apt/preferences && \
+    echo "Pin: origin \"packages.microsoft.com\"" >> /etc/apt/preferences && \
+    echo "Pin-Priority: 1001" >> /etc/apt/preferences && \
+    add-apt-repository universe && \
+    apt update && \
+    apt-get install -y dotnet-sdk-${DOTNET_VERSION}
 
 # TODO remove once determined it is no longer needed
  #   apt-get install -y powershell

--- a/omega/analyzer/Dockerfile
+++ b/omega/analyzer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/mirror/docker/library/ubuntu:22.04
+FROM --platform=linux/amd64 mcr.microsoft.com/mirror/docker/library/ubuntu:22.04
 
 # Copyright (C) Microsoft Corporation, All rights reserved.
 
@@ -19,7 +19,7 @@ ARG SCC_VERSION="3.0.0"
 ARG NODE_VERSION="18.x"
 ARG DEVSKIM_VERSION="0.8.4-alpha"
 ARG RADARE2_VERSION="5.7.8"
-ARG CODEQL_VERSION="v2.11.4"
+ARG CODEQL_VERSION="v2.11.6"
 
 # Initialize some things
 ARG DEBIAN_FRONTEND=noninteractive
@@ -114,18 +114,20 @@ RUN apt-get update && \
 # License: https://github.com/dotnet/core/blob/main/LICENSE.TXT
 # License: https://github.com/PowerShell/PowerShell/blob/master/LICENSE.txt
 # Workaround with /etc/apt/preferences based on https://github.com/dotnet/core/issues/7699
-RUN cd /tmp && \
-    wget -q https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
-    dpkg -i packages-microsoft-prod.deb && \
-    rm packages-microsoft-prod.deb && \
-    touch /etc/apt/preferences && \
-    echo "Package: *" >> /etc/apt/preferences && \
-    echo "Pin: origin \"packages.microsoft.com\"" >> /etc/apt/preferences && \
-    echo "Pin-Priority: 1001" >> /etc/apt/preferences && \
-    add-apt-repository universe && \
-    apt update && \
-    apt-get install -y dotnet-sdk-${DOTNET_VERSION} && \
-    apt-get install -y powershell
+#RUN cd /tmp && \
+#    wget -q a -O packages-microsoft-prod.deb && \
+#    dpkg -i packages-microsoft-prod.deb && \
+#    rm packages-microsoft-prod.deb && \
+#    touch /etc/apt/preferences && \
+#    echo "Package: *" >> /etc/apt/preferences && \
+#    echo "Pin: origin \"packages.microsoft.com\"" >> /etc/apt/preferences && \
+#    echo "Pin-Priority: 1001" >> /etc/apt/preferences && \
+#    add-apt-repository universe && \
+#    apt update && \
+#    apt-get install -y dotnet-sdk-${DOTNET_VERSION} && \
+
+# TODO remove once determined it is no longer needed
+ #   apt-get install -y powershell
 
 # Install Go
 # License: https://github.com/golang/go/blob/master/LICENSE

--- a/omega/analyzer/Dockerfile
+++ b/omega/analyzer/Dockerfile
@@ -1,4 +1,3 @@
-#FROM --platform=linux/amd64 mcr.microsoft.com/mirror/docker/library/ubuntu:22.04
 FROM mcr.microsoft.com/mirror/docker/library/ubuntu:22.04
 # Copyright (C) Microsoft Corporation, All rights reserved.
 
@@ -106,7 +105,6 @@ RUN apt-get update && \
             sudo \
             openssh-client \
             openjdk-17-jdk
-#    apt-get update
 
 ##################################
 ####### Install Core Tools #######

--- a/omega/analyzer/README.md
+++ b/omega/analyzer/README.md
@@ -19,6 +19,30 @@ hardware.
 
 We're exploring making the pre-built image available.
 
+### Troubleshooting steps
+
+#### MacOS M1 Chip
+If using a Mac OSX with the latest Docker Desktop (4.15 as of writing), `docker build build.ps1` will shoot out several error messages.
+
+Make sure to create `/etc/apt/` with sudo user
+
+Download and install
+* `wget` with `brew install wget`
+* `dkpg` with `brew install dpkg`
+* .NET core with `brew install mono-libgdiplus`
+
+There is a known issue with [M1 Apple chip on MacOS](https://stackoverflow.com/questions/71040681/qemu-x86-64-could-not-open-lib64-ld-linux-x86-64-so-2-no-such-file-or-direc), which would produce the error when running
+
+```qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory```
+
+The following two options are available to work around this issue:
+1. Set the DOCKER_DEFAULT_PLATFORM environment variable to linux/amd64
+
+`export DOCKER_DEFAULT_PLATFORM=linux/amd64`
+2. In the FROM section of the Dockerfile, line 1, modify to the following
+
+`FROM --platform=linux/amd64 mcr.microsoft.com/mirror/docker/library/ubuntu:22.04`
+
 ## Running
 
 To run the image, navigate to the `worker` directory and run the `run-analysis.ps1`

--- a/omega/analyzer/README.md
+++ b/omega/analyzer/README.md
@@ -21,16 +21,6 @@ We're exploring making the pre-built image available.
 
 ### Troubleshooting steps
 
-#### Windows
-Ensure you have the following installed on your machine:
-* wget via [GNU WGET](https://eternallybored.org/misc/wget/)
-
-Download the latest version zip file.
-Unzip it
-Copy the wget.exe file into C:\Program Files\Git\mingw64\bin
-
-C:\Program Files\Git\mingw64\bin is my Git Bash tool path.
-
 #### MacOS M1 Chip
 If using a Mac OSX with the latest Docker Desktop (4.15 as of writing), `docker build build.ps1` will shoot out several error messages.
 

--- a/omega/analyzer/README.md
+++ b/omega/analyzer/README.md
@@ -21,6 +21,16 @@ We're exploring making the pre-built image available.
 
 ### Troubleshooting steps
 
+#### Windows
+Ensure you have the following installed on your machine:
+* wget via [GNU WGET](https://eternallybored.org/misc/wget/)
+
+Download the latest version zip file.
+Unzip it
+Copy the wget.exe file into C:\Program Files\Git\mingw64\bin
+
+C:\Program Files\Git\mingw64\bin is my Git Bash tool path.
+
 #### MacOS M1 Chip
 If using a Mac OSX with the latest Docker Desktop (4.15 as of writing), `docker build build.ps1` will shoot out several error messages.
 


### PR DESCRIPTION
Patched the dockerfile to comment out the installation of powershell and update the README file for troubleshooting several of the build issues related to M1 Apple Chip.

https://github.com/ossf/alpha-omega/issues/70 - Migrate the Toolshed powershell scripts to bash
https://github.com/ossf/alpha-omega/issues/81 - MacBook bug: Unable to locate package powershell

PR https://github.com/ossf/alpha-omega/pull/96 updated the branch. This push will update the dockerfile and readme