### PR TITLE
Add extra args to assertion generator; use for filtering tool findings.

### DIFF
--- a/omega/oaf/omega/assertion/assertion/securitytoolfinding.py
+++ b/omega/oaf/omega/assertion/assertion/securitytoolfinding.py
@@ -36,9 +36,12 @@ class SecurityToolFinding(BaseAssertion):
         self.filtered_results = []  # type: typing.Generator[dict, None, None]
         self.severity_map = {}  # type: dict[str, int]
         self.include_evidence = kwargs.get("include_evidence", True)
+        self.filter = kwargs.get("filter", None)
+        if self.filter:
+            if self.filter.startswith('lambda '):
+                self.filter = eval(self.filter)     # Dangerous, need to be careful here.
 
         self.input_file = kwargs.get("input_file")
-
         if not self.input_file or not os.path.isfile(self.input_file):
             raise IOError(f"Input file [{self.input_file}] does not exist")
 
@@ -69,12 +72,9 @@ class SecurityToolFinding(BaseAssertion):
                     Reproducibility.UNKNOWN,
                 )
 
-        # Filter the results
-        def delegate(_) -> bool:
-            return True  # Get them all
-
         sarif_helper = SarifHelper(self.data)
-        self.filtered_results = sarif_helper.filter(delegate)
+        self.filtered_results = sarif_helper.filter(self.filter)
+
         self.severity_map = defaultdict(int)
 
         for result in self.filtered_results:

--- a/omega/oaf/omega/oaf.py
+++ b/omega/oaf/omega/oaf.py
@@ -73,6 +73,7 @@ class OAF:
             required=False,
         )
         p_generate.add_argument("--expiration", help="Expiration date", type=str, required=False)
+        p_generate.add_argument("--extra-args", help="Extra parameters (key=value)", type=str, required=False)
 
         # Consume Assertions
         p_consume = subparsers.add_parser("consume", help="Consume assertions")
@@ -265,6 +266,14 @@ class OAF:
 
                 additional_args = vars(additional_args)
                 additional_args.pop("subject")
+
+                # Append extra arguments, but do not overwrite
+                if 'extra_args' in additional_args:
+                    extra_args = OAF.Generate.parse_kv_args(additional_args.get('extra_args'))
+                    for key, value in extra_args.items():
+                        if key not in additional_args:
+                            additional_args[key] = value
+
                 assertion = cls(subject, **additional_args)  # type: BaseAssertion
                 try:
                     assertion.process()
@@ -281,6 +290,20 @@ class OAF:
             )
             return None
 
+        @staticmethod
+        def parse_kv_args(args):
+            """Parses a key=value string or a list of key=value strings into a dict."""
+            results = {}
+            if not args:
+                return results
+
+            if not isinstance(args, list):
+                args = [args]
+
+            for arg in args:  # type: str
+                k, v = arg.split('=', 1)
+                results[k.strip()] = v.strip()
+            return results
 
 if __name__ == "__main__":
     oaf = OAF()


### PR DESCRIPTION
This PR makes it easier to provide a filter to the assertion generator to take only a subset of a list of findings. This is only applicable currently for the SecurityToolFinding assertion generator.

Usage:
```
        # Static Analyzers (SARIF)
        for _filename in ['tool-semgrep.sarif', 'tool-devskim.sarif', 'tool-codeql-basic.javascript.sarif', 'tool-snyk-code.sarif']:
            self._execute_assertion_noexcept(
                **{
                    "assertion": "SecurityToolFinding",
                    "subject": self.package_url,
                    "input-file": self.find_output_file(_filename),
                    "repository": self.repository,
                    "signer": self.signer,
                    "filter": "lambda c: c.get('rule_id') == 'ABCD1234'"
                }
            )
```

The rule filtering is defined in SarifHelper:
```
                    result = {
                        "rule_id": result.get("ruleId"),
                        "filename": _filename,
                        "snippet": snippet,
                        "start_line": start_line,
                        "end_line": end_line,
                    }
```

Note that the content of filter is a string, which is passed (as a string) into oaf.py and eval'ed back to a lambda. This is inherently dangerous, so we should think about refactoring analyze.py to call oaf functions directly instead of doing it through a subprocess.

Signed-off-by: Michael Scovetta <michael.scovetta@gmail.com>