### PR TITLE
Update a typo in a field

### DIFF
--- a/alpha/engagements/2023/OpenRefactory/update-2023-08.md
+++ b/alpha/engagements/2023/OpenRefactory/update-2023-08.md
@@ -11,7 +11,7 @@ The outcome of these efforts thus far:
 |  | Aug 2023 |
 |--|--|
 | Projects analyzed | 132 |
-| Projects with no bugs | 15 (45%) |
+| Projects with no bugs | 98 |
 | Total bugs filed | 33 |
 | Security bugs filed | 12 |
 | Bugs with a fix suggestion | 26 |


### PR DESCRIPTION
No of projects that had no bugs is 98. It had the wrong value before.