### PR TITLE
Homebrew: fill in README

### DIFF
--- a/alpha/engagements/2023/Homebrew/README.md
+++ b/alpha/engagements/2023/Homebrew/README.md
@@ -1,1 +1,21 @@
+# Alpha Engagement: Build provenance for Homebrew
 
+The purpose of this Alpha engagement is to fund the development of build
+provenance for Homebrew (and specifically `homebrew-core`).
+
+The full technical proposal can be found here:
+[Build Provenance and Code-signing for Homebrew].
+
+[Build Provenance and Code-signing for Homebrew]: https://repos.openssf.org/proposals/build-provenance-and-code-signing-for-homebrew
+
+## Timeline
+
+This engagement started in October 2023.
+
+## Monthly Updates
+
+## Primary Contacts
+
+* William Woodruff - Trail of Bits
+
+## Announcement / News


### PR DESCRIPTION
This fills in the 2023 Homebrew engagement's README a bit, including a link to the SSR WG's original proposal 🙂 

I haven't filled in the timeline or announcement sections yet; I'll do the initial timeline report (for Oct 2023) in a subsequent PR.