### PR TITLE
jQuery: add April 2024 update

### DIFF
--- a/alpha/engagements/2024/jQuery/README.md
+++ b/alpha/engagements/2024/jQuery/README.md
@@ -11,7 +11,7 @@ in key areas, including:
 
 ### Timeline
 
-This engagement started in December 2022.
+This engagement started in December 2022. Work in 2024 is being done with carryover funds from 2023.
 
 ### Monthly Updates
 

--- a/alpha/engagements/2024/jQuery/README.md
+++ b/alpha/engagements/2024/jQuery/README.md
@@ -18,6 +18,7 @@ This engagement started in December 2022. Work in 2024 is being done with carryo
 * [Janurary 2024](update-2024-01.md)
 * [February 2024](update-2024-02.md)
 * [March 2024](update-2024-03.md)
+* [April 2024](update-2024-04.md)
 
 ### Primary Contacts
 

--- a/alpha/engagements/2024/jQuery/update-2024-04.md
+++ b/alpha/engagements/2024/jQuery/update-2024-04.md
@@ -2,14 +2,14 @@
 
 ## jQuery Testing Infrastructure
 
-Work has been completed to migrate testing infrastructure on four jQuery projects. jQuery Core (both `main` and `3.x-stable` branches), [jQuery Migrate](https://github.com/jquery/jquery-migrate/pull/503), and [jQuery UI](https://github.com/jquery/jquery-ui/pull/2221) were completed previously. Similar work has been completed for [jQuery Color](https://github.com/jquery/jquery-color/pull/135). This includes:
+Work has been completed to migrate testing infrastructure on four jQuery projects. jQuery Core (both `main` and `3.x-stable` branches), [jQuery Migrate](https://github.com/jquery/jquery-migrate/pull/503), and [jQuery UI](https://github.com/jquery/jquery-ui/pull/2221) were completed previously. Similar work has now been completed for [jQuery Color](https://github.com/jquery/jquery-color/pull/135). This includes:
 
 - Migrating the testing scripts from `grunt` to `npm` scripts.
-- Migrating the test suite from TestSwarm, which runs on an old Jenkins server, to GitHub Actions.
-- Migrating the test suite from Karma to using [Selenium WebDriver](https://www.selenium.dev/documentation/webdriver/)  for local testing and [BrowserStack's REST API](https://github.com/browserstack/api) for local and CI testing on BrowserStack.
+- Migrating QUnit test suite from TestSwarm, and the old Jenkins server, to GitHub Actions.
+- Migrating QUnit test suite from Karma to using [Selenium WebDriver](https://www.selenium.dev/documentation/webdriver/) for local testing, and from testswarm-browserstack to directly [BrowserStack's REST API](https://github.com/browserstack/api) for CI testing.
 - Building a standalone test server using Express and mock middleware.
 
-Now that this is complete, we are almost ready to decommission the jenkins.jquery.com and associated database as well as the infrastructure for TestSwarm. We will wait a few weeks to test jQuery UI after its recent 1.13.3 release in case any issues are found.
+Now that this is complete, we are almost ready to decommission the jenkins.jquery.com, as well as the infrastructure for TestSwarm. We will wait a few weeks to test jQuery UI after its recent 1.13.3 release in case any issues are found.
 
 ## plugins.jquery.com
 
@@ -19,8 +19,8 @@ The jQuery plugins site archive has been deployed. This is a static site that co
 
 As part of the [Healthy Web Checkup campaign](https://openjsf.org/blog/healthy-web-checkup), the OpenJS Foundation has been [working with the jQuery team](https://blog.jquery.com/2024/04/17/upgrading-jquery-working-towards-a-healthy-web/) to encourage users to improve the security of their sites. Updating jQuery is a small part of that, but an old jQuery is often a sign of a site that hasn't been maintained.
 
-A tool has been deployed to healthyweb.org that can check the version of jQuery on a site and provide guidance on how to update it. The tool is available at [https://healthyweb.org/](https://healthyweb.org/).
+A tool has been deployed to healthyweb.org that can check the version of jQuery on a site and provide guidance on how to update it. The tool is available at [https://healthyweb.org/](https://healthyweb.org/). Source at <https://github.com/jquery/jquery-detect>.
 
 ## gzip issue for some CDN files
 
-The jQuery team received a report that some files on the new CDN (fastly) were not being gzipped. We are still investigating, but for now have enabled gzip at both the Fastly level and at the source from nginx.
+The jQuery team received a report that some files on the new CDN (Fastly) were not being gzipped. We are still investigating, but for now have enabled a gzip override at the Fastly level, in addition to what nginx already does at the origin.

--- a/alpha/engagements/2024/jQuery/update-2024-04.md
+++ b/alpha/engagements/2024/jQuery/update-2024-04.md
@@ -1,0 +1,26 @@
+# Update 2024-04
+
+## jQuery Testing Infrastructure
+
+Work has been completed to migrate testing infrastructure on four jQuery projects. jQuery Core (both `main` and `3.x-stable` branches), [jQuery Migrate](https://github.com/jquery/jquery-migrate/pull/503), and [jQuery UI](https://github.com/jquery/jquery-ui/pull/2221) were completed previously. Similar work has been completed for [jQuery Color](https://github.com/jquery/jquery-color/pull/135). This includes:
+
+- Migrating the testing scripts from `grunt` to `npm` scripts.
+- Migrating the test suite from TestSwarm, which runs on an old Jenkins server, to GitHub Actions.
+- Migrating the test suite from Karma to using [Selenium WebDriver](https://www.selenium.dev/documentation/webdriver/)  for local testing and [BrowserStack's REST API](https://github.com/browserstack/api) for local and CI testing on BrowserStack.
+- Building a standalone test server using Express and mock middleware.
+
+Now that this is complete, we are almost ready to decommission the jenkins.jquery.com and associated database as well as the infrastructure for TestSwarm. We will wait a few weeks to test jQuery UI after its recent 1.13.3 release in case any issues are found.
+
+## plugins.jquery.com
+
+The jQuery plugins site archive has been deployed. This is a static site that contains the contents of the old plugins.jquery.com site. The site is available at [https://plugins.jquery.com/](https://plugins.jquery.com/).
+
+## healthyweb.org
+
+As part of the [Healthy Web Checkup campaign](https://openjsf.org/blog/healthy-web-checkup), the OpenJS Foundation has been [working with the jQuery team](https://blog.jquery.com/2024/04/17/upgrading-jquery-working-towards-a-healthy-web/) to encourage users to improve the security of their sites. Updating jQuery is a small part of that, but an old jQuery is often a sign of a site that hasn't been maintained.
+
+A tool has been deployed to healthyweb.org that can check the version of jQuery on a site and provide guidance on how to update it. The tool is available at [https://healthyweb.org/](https://healthyweb.org/).
+
+## gzip issue for some CDN files
+
+The jQuery team received a report that some files on the new CDN (fastly) were not being gzipped. We are still investigating, but for now have enabled gzip at both the Fastly level and at the source from nginx.


### PR DESCRIPTION
This will be the last update provided by jQuery, which is not technically part of the 2024 cohort.