### PR TITLE
Drop the broken jQuery category link

### DIFF
--- a/alpha/engagements/2022/jquery/README.md
+++ b/alpha/engagements/2022/jquery/README.md
@@ -27,4 +27,3 @@ This engagement started in December 2022 and is expected to continue through at 
 ### Announcement / News
 
 * <https://openssf.org/blog/2022/10/24/openssf-project-alpha-omega-invests-in-the-openjs-foundation-and-jquery-to-help-secure-the-consumer-web/>
-* <https://openjsf.org/category/jquery/>

--- a/alpha/engagements/2023/jquery/README.md
+++ b/alpha/engagements/2023/jquery/README.md
@@ -40,5 +40,4 @@ This engagement started in December 2022 and is expected to continue through at 
 ### Announcement / News
 
 * <https://openssf.org/blog/2022/10/24/openssf-project-alpha-omega-invests-in-the-openjs-foundation-and-jquery-to-help-secure-the-consumer-web/>
-* <https://openjsf.org/category/jquery/>
 

--- a/alpha/engagements/2024/jQuery/README.md
+++ b/alpha/engagements/2024/jQuery/README.md
@@ -29,5 +29,4 @@ This engagement started in December 2022. Work in 2024 is being done with carryo
 ### Announcement / News
 
 * <https://openssf.org/blog/2022/10/24/openssf-project-alpha-omega-invests-in-the-openjs-foundation-and-jquery-to-help-secure-the-consumer-web/>
-* <https://openjsf.org/category/jquery/>
 


### PR DESCRIPTION
Dropping the jQuery link that is no longer with as reported in #351.