### PR TITLE
alpha: add PyPI package lifecycle engagement

### DIFF
--- a/alpha/engagements/2024/PyPI/README.md
+++ b/alpha/engagements/2024/PyPI/README.md
@@ -1,0 +1,29 @@
+# Alpha Engagement: PyPI Package Lifecycle Engineering
+
+The purpose of this Alpha engagement is to fund the development
+of fixes and enhancements to the Python packaging ecosystem's
+project "lifecycle," with particular focus on:
+
+1. Improving the reliability of index retrieval by driving the
+   ecosystem towards a soft removal model ("yanking") instead of hard
+   deletion;
+2. Improving project status reporting abilities, including giving
+   Python project maintainers the ability to emit structured metadata
+   on PyPI regarding a project's status (e.g. "finished", "archived",
+   "deprecated", etc.);
+3. Adding support for project drafting and bulk uploads (i.e. multi-file
+   uploads) to PyPI, via an implementation of [PEP 694].
+
+## Timeline
+
+This engagement started in September 2024.
+
+## Monthly updates
+
+* [Semptember 2024](./update-2023-09.md)
+
+## Primary Contacts
+
+* William Woodruff - Trail of Bits
+
+[PEP 694]: https://peps.python.org/pep-0694/

--- a/alpha/engagements/2024/PyPI/update-2023-09.md
+++ b/alpha/engagements/2024/PyPI/update-2023-09.md
@@ -1,0 +1,22 @@
+# PyPI Package Lifecycle Engineering: September 2024
+
+*Logistical note*: This is our first status update, and reflects
+only a limited number of hours used this month.
+
+## In progress
+
+* Revived the standards process for [PEP 694] and began reviewing the latest
+  draft changes. Coordinating with the PEP's authors/delegates on steps
+  towards finalizing and provisionally accepting the PEP.
+* Began a [pre-PEP discussion] for limiting deletions on PyPI. Currently
+  drafting the accompanying PEP.
+* Began preliminary development on deletion eligibility logic for files,
+  releases, and projects on PyPI.
+  * Draft PR: https://github.com/pypi/warehouse/pull/16813
+* Began preliminary development on project status markers. Coordinating
+  with PyPI's security and safety engineer on design and implementation
+  timeline.
+
+[PEP 694]: https://peps.python.org/pep-0694/
+
+[pre-PEP discussion]: https://discuss.python.org/t/pre-pep-limiting-deletions-on-pypi/66351


### PR DESCRIPTION
This adds a new engagement listing for the PyPI package lifecycle engagement, and adds the first monthly status report for that engagement as well.