### PR TITLE
PyPI, PyCA: March 2025 updates

### DIFF
--- a/alpha/engagements/2024/PyPI/README.md
+++ b/alpha/engagements/2024/PyPI/README.md
@@ -26,6 +26,7 @@ This engagement started in September 2024.
 * [December 2024](./update-2024-12.md)
 * [January 2025](./update-2025-01.md)
 * [February 2025](./update-2025-02.md)
+* [March 2025](./update-2025-03.md)
 
 ## Primary Contacts
 

--- a/alpha/engagements/2024/PyPI/update-2025-03.md
+++ b/alpha/engagements/2024/PyPI/update-2025-03.md
@@ -1,0 +1,33 @@
+# PyPI Package Lifecycle Engineering: March 2025
+
+*Logistical note*: We spent marginal hours on this project in March 2025.
+As such, our update primarily reflects the previous month's ongoing tasks.
+
+## Completed
+
+* Completed transition of user documentation away from `help.html` and
+  into the new user documentation system, including documentation on
+  yanking, deletion, and storage quotas:
+
+    - <https://github.com/pypi/warehouse/pull/17716>
+    - <https://github.com/pypi/warehouse/issues/17702>
+    - <https://github.com/pypi/warehouse/issues/9013>
+
+## In progress
+
+* Began work on DB migration squashing/optimization:
+    - https://github.com/pypi/warehouse/pull/17652
+    - https://github.com/pypi/warehouse/pull/17607
+    - https://github.com/pypi/warehouse/issues/17590
+
+* Continued development on draft upload support:
+
+    - <https://github.com/pypi/warehouse/pull/17257>
+    - <https://github.com/trail-of-forks/warehouse/pull/3116>
+    - <https://github.com/trail-of-forks/warehouse/pull/3051>
+    - <https://github.com/pypi/warehouse/pull/17331>
+
+
+## Upcoming
+
+* Resuming authoring and editing on a project status marker PEP.

--- a/alpha/engagements/2025/PyCA/README.md
+++ b/alpha/engagements/2025/PyCA/README.md
@@ -18,6 +18,7 @@ This engagement started in January 2025.
 
 * [January 2025](./update-2025-01.md)
 * [February 2025](./update-2025-02.md)
+* [March 2025](./update-2025-03.md)
 
 ## Primary Contacts
 

--- a/alpha/engagements/2025/PyCA/update-2025-03.md
+++ b/alpha/engagements/2025/PyCA/update-2025-03.md
@@ -1,0 +1,11 @@
+# PyCA Cryptography Declarative ASN.1 API: March 2025
+
+*Logistical note*: We spent marginal hours on this project in March 2025.
+As such, our update primarily reflects the previous month's ongoing tasks.
+
+## In progress
+
+* Continued development on the Rust internals, including MVP support
+  for serialization and deserialization.
+* Began design of non-trivial annotation support, including
+  support for `IMPLICIT`, `EXPLICIT`, etc. ASN.1 markers.


### PR DESCRIPTION
Apologies for the tardy updates here! Both of these are pretty brief, as ToB spent marginal engineering time on any projects this past March due to a company offsite and other overlapping projects.

Both projects resumed normal development pacing in April, and so we'll have much more to report this coming month 🙂 

CC @michaelwinser @micmarti85 