### PR TITLE
Fix UnboundLocalError in get_package_url_with_version

### DIFF
--- a/omega/oaf/omega/assertion/utils.py
+++ b/omega/oaf/omega/assertion/utils.py
@@ -133,6 +133,7 @@ def get_package_url_with_version(package_url: PackageURL | str) -> PackageURL:
     # Try using the libraries.io API
     # HACK: Libraries.io knows RubyGems as "pkg:rubygems", nor "pkg:gem", so we need
     #       to convert it to the correct format.
+    mod_purl = purl
     if purl.type == "gem":
         mod_purl = PackageURL(type="rubygems", name=purl.name, version=purl.version)
 


### PR DESCRIPTION

## 1. Issue & PR: Fix UnboundLocalError in `get_package_url_with_version`

### branch: `fix/utils-unbound-local-error`

### GitHub Issue Description
**Title:** `UnboundLocalError` when retrieving package version for non-gem packages in `utils.py`

**Description:**
A bug exists in `omega/oaf/omega/assertion/utils.py` inside the `get_package_url_with_version` function.
When the lookup falls back to using the libraries.io API, the code attempts to reference `mod_purl` when passing it to `oss-metadata`:
```python
    # Try using the libraries.io API
    # HACK: Libraries.io knows RubyGems as "pkg:rubygems", nor "pkg:gem", so we need
    #       to convert it to the correct format.
    if purl.type == "gem":
        mod_purl = PackageURL(type="rubygems", name=purl.name, version=purl.version)

    res = subprocess.run([
        "oss-metadata",
        "-s",
        "libraries.io",
        str(mod_purl)
    ], capture_output=True, timeout=10, check=False)
```
If `purl.type` is not `"gem"`, the local variable `mod_purl` is never initialized. When `str(mod_purl)` is executed on line 143, it raises `UnboundLocalError: cannot access local variable 'mod_purl' where it is not associated with a value`.

**Steps to Reproduce:**
Call `get_package_url_with_version` with a versionless non-gem package (e.g. `pkg:npm/nonexistent-package-abc-123`). The deps.dev lookup will fail, causing it to fall through to libraries.io lookup, raising an `UnboundLocalError`.

---

### GitHub PR Description
**Title:** Fix UnboundLocalError for non-gem packages in libraries.io lookup path

**Description:**
This PR resolves the `UnboundLocalError` in `get_package_url_with_version` by ensuring `mod_purl` is always defined. 

**Changes Made:**
- Modified [utils.py](file:///c:/opensource/alpha-omega/omega/oaf/omega/assertion/utils.py) to initialize `mod_purl = purl` by default before verifying if `purl.type == "gem"`.

**Verification:**
Verified by running `get_package_url_with_version` with a versionless non-gem PackageURL. Previously, this crashed with `UnboundLocalError` on line 143. Now, it runs past that line successfully and only fails with `FileNotFoundError` if the external `oss-metadata` command is missing (which is expected).
