### PR TITLE
Fix file check logic in SecurityScorecard.load_input_file

### DIFF
--- a/omega/oaf/omega/assertion/assertion/securityscorecard.py
+++ b/omega/oaf/omega/assertion/assertion/securityscorecard.py
@@ -92,7 +92,7 @@ class SecurityScorecard(BaseAssertion):
 
     def load_input_file(self) -> bool:
         """Loads scorecard data from an input file."""
-        if not self.input_file or os.path.isfile(self.input_file):
+        if not self.input_file or not os.path.isfile(self.input_file):
             return False
 
         logging.debug("Reading input file: %s", self.input_file)


### PR DESCRIPTION
## 2. Issue & PR: Fix incorrect file check negation in `SecurityScorecard.load_input_file`

### branch: `fix/security-scorecard-file-check`

### GitHub Issue Description
**Title:** `SecurityScorecard.load_input_file` fails to load existing files due to backward check logic

**Description:**
A bug exists in `omega/oaf/omega/assertion/assertion/securityscorecard.py` inside the `load_input_file` method.
The function is designed to load scorecard data from a local JSON file if `self.input_file` is specified. However, the condition on lines 95-96 returns `False` if `self.input_file` is a file:
```python
    def load_input_file(self) -> bool:
        """Loads scorecard data from an input file."""
        if not self.input_file or os.path.isfile(self.input_file):
            return False
```
If `self.input_file` is a valid, existing file, `os.path.isfile(self.input_file)` evaluates to `True`. Because of the `or` condition, the method immediately returns `False` without reading the file.

**Steps to Reproduce:**
1. Instantiate `SecurityScorecard` with an existing JSON input file.
2. Call `load_input_file()`.
3. Notice that it immediately returns `False` and never reads the file.

---

### GitHub PR Description
**Title:** Fix input file check negation in SecurityScorecard.load_input_file

**Description:**
This PR corrects the file existence validation check in `load_input_file` of the `SecurityScorecard` assertion. 

**Changes Made:**
- Modified [securityscorecard.py](file:///c:/opensource/alpha-omega/omega/oaf/omega/assertion/assertion/securityscorecard.py) to check `not os.path.isfile(self.input_file)` instead of `os.path.isfile(self.input_file)`.

**Verification:**
Verified that `load_input_file()` now correctly proceeds to read and parse the file if it is an existing file, returning `True` on success.
