### PR TITLE
Fix expiration check condition in BaseAssertion.expiration setter

### DIFF
--- a/omega/oaf/omega/assertion/assertion/base.py
+++ b/omega/oaf/omega/assertion/assertion/base.py
@@ -176,7 +176,7 @@ class BaseAssertion:
             return
 
         if isinstance(value, str):
-            if not str:
+            if not value.strip():
                 self._expiration = None
                 return
 


### PR DESCRIPTION
## 3. Issue & PR: Fix boolean class validation in `BaseAssertion.expiration` setter

### branch: `fix/base-assertion-expiration-check`

### GitHub Issue Description
**Title:** Class name `str` used instead of variable `value` in `BaseAssertion.expiration` setter

**Description:**
A bug exists in `omega/oaf/omega/assertion/assertion/base.py` within the `expiration` property setter.
The setter attempts to validate if an empty/whitespace string was passed so it can reset expiration to `None`:
```python
        if isinstance(value, str):
            if not str:
                self._expiration = None
                return
```
Instead of checking the instance variable `value`, the condition checks `not str`. Since `str` is the builtin class name, `not str` is always evaluated as `False`. Thus, empty strings bypass this check and are passed to `date_parse(value, fuzzy=True)`, which throws a `ParserError`.

**Steps to Reproduce:**
1. Instantiate `BaseAssertion` subclass or base class.
2. Set its `expiration` property to an empty string `""`.
3. Notice that it raises a `dateutil.parser.ParserError` instead of setting `_expiration` to `None`.

---

### GitHub PR Description
**Title:** Fix expiration setter to check value instance instead of builtin class

**Description:**
This PR corrects the string validation logic in the `expiration` property setter of `BaseAssertion`.

**Changes Made:**
- Modified [base.py](file:///c:/opensource/alpha-omega/omega/oaf/omega/assertion/assertion/base.py) to check `not value.strip()` instead of `not str`.

**Verification:**
Verified by assigning an empty string `""` to the `expiration` property on a `BaseAssertion` object. It now correctly sets `expiration` to `None` without raising any parse exceptions.
