### PR TITLE
docs: fix grammar in Omega Analyzer README

### DIFF
--- a/omega/analyzer/README.md
+++ b/omega/analyzer/README.md
@@ -4,7 +4,7 @@ The Omega Analyzer is a self-contained container image that has a broad set of s
 preinstalled, along with an orchestration script to run those tools against a target and
 aggregate the results.
 
-While it can be used interactively, it's primary purpose is to be run from the host, with
+While it can be used interactively, its primary purpose is to be run from the host, with
 output send to a mapped directory.
 
 ## Building


### PR DESCRIPTION
Small typo in the Omega Analyzer README "it's primary purpose" should be "its primary purpose" (possessive, not a contraction). Fixed the wording, no other changes.